### PR TITLE
same ids in documentation

### DIFF
--- a/source/includes/_bulks.md
+++ b/source/includes/_bulks.md
@@ -1,1 +1,3 @@
 # Bulks
+
+Documentation not ready.

--- a/source/includes/_campaigns.md
+++ b/source/includes/_campaigns.md
@@ -1,1 +1,3 @@
 # Campaigns
+
+Documentation not ready.

--- a/source/includes/_companies.md
+++ b/source/includes/_companies.md
@@ -1,1 +1,3 @@
 # Company
+
+Documentation not ready.

--- a/source/includes/_invoices.md
+++ b/source/includes/_invoices.md
@@ -64,7 +64,7 @@ Content-Type: application/json
    "due_date":{
       "$date":1476551410009
    },
-   "message":"12313123",
+   "message":"Some message to the Issuer",
    "account_number":"12345678903",
    "user":{
       "$oid":"57ee9c72d76d431f85111432"

--- a/source/includes/_issuers.md
+++ b/source/includes/_issuers.md
@@ -49,7 +49,7 @@ Content-Type: application/json
    "active":true,
    "name":"Create_issuer",
    "company":{
-      "$oid":"58de5a46b70e2a8840ea4aa6"
+      "$oid":"57ee9c71d76d431f8511142f"
    },
    "comments":"It is a comment",
    "address":{
@@ -63,7 +63,7 @@ Content-Type: application/json
    "logo_url":"http://logok.org/wp-content/uploads/2014/10/Telenor_logo-and-wordmark.png",
    "account_number":"12345678903",
    "_id":{
-      "$oid":"58de5a47b70e2a8840ea4aae"
+      "$oid":"57ee9c72d76d431f85111433"
    }
 }
 ```
@@ -101,23 +101,23 @@ Content-Type: application/json
 
 {
     "blacklisted": false,
-    "name": "Telenor Norge AS",
+    "name": "Big Company Inc",
     "company": {
-        "$oid": "58e104d5b70e2a76c0e94c83"
+        "$oid": "57ee9c71d76d431f8511142f"
     }, 
     "deleted": false,
     "verified": false,
     "_id": {
-        "$oid": "58e104d5b70e2a76c0e94c85"
+        "$oid": "57ee9c72d76d431f85111433"
     },
     "account_number": "12345678903",
-    "logo_url": "http://logok.org/wp-content/uploads/2014/10/Telenor_logo-and-wordmark.png",
+    "logo_url": "<logo-url.png>",
     "address": {
-        "street_name": "Fornebuveien 6",
+        "street_name": "Money Lane 99",
         "alias": "",
         "service": "google",
         "city": "Oslo",
-        "zip_code": "0556",
+        "zip_code": "1234",
         "country": "NOR"
     }, 
     "is_message_mandatory": false,
@@ -158,16 +158,16 @@ Content-Type: application/json
       "blacklisted":false,
       "active":true,
       "_id": {
-         "$oid":"58e10791b70e2a516c376a8c"
+         "$oid":"57ee9c72d76d431f85111433"
       },
-      "logo_url":"http://logok.org/wp-content/uploads/2014/10/Telenor_logo-and-wordmark.png",
-      "address": {
-         "country":"NOR",
-         "street_name":"Fornebuveien 6",
-         "city":"Oslo",
-         "zip_code":"0556",
-         "service":"google",
-         "alias":""
+      "logo_url": "<logo-url.png>",
+      "address": { 
+            "street_name": "Money Lane 99", 
+            "alias": "", 
+            "service": "google", 
+            "city": "Oslo", 
+            "zip_code": "1234", 
+            "country": "NOR" 
       },
       "created": {
          "$date":1491142545321
@@ -177,9 +177,9 @@ Content-Type: application/json
       },
       "verified":false,
       "deleted":false,
-      "name":"Telenor Norge AS",
+      "name":"Big Company Inc",
       "company": {
-         "$oid":"58e10791b70e2a516c376a8a"
+         "$oid":"57ee9c71d76d431f8511142f"
       }
     }
 ]
@@ -220,28 +220,28 @@ Content-Type: application/json
 
 {  
    "company":{
-      "$oid":"58e112acb70e2a326cf1f955"
+      "$oid":"57ee9c71d76d431f8511142f"
    },
-   "name":"Telenor updated",
+   "name":"Big Company Ltd",
    "modified":{
       "$date":1491145388209
    },
    "is_message_mandatory":false,
    "_id":{
-      "$oid":"58e112acb70e2a326cf1f957"
+      "$oid":"57ee9c72d76d431f85111433"
    },
    "created":{
       "$date":1491145388109
    },
    "deleted":false,
-   "logo_url":"http://logok.org/wp-content/uploads/2014/10/Telenor_logo-and-wordmark.png",
-   "address":{
-      "service":"google",
-      "street_name":"Fornebuveien 6",
-      "city":"Oslo",
-      "zip_code":"0556",
-      "country":"NOR",
-      "alias":""
+   "logo_url":"<logo-url.png>",
+    "address": {
+        "street_name": "Money Lane 99",
+        "alias": "",
+        "service": "google",
+        "city": "Oslo",
+        "zip_code": "1234",
+        "country": "NOR"
    },
    "verified":false,
    "account_number":"12345678903",
@@ -259,7 +259,7 @@ Arguments | Descriptions
 ## Issuer Search
 
 ``` http
-GET /issuers/search?query=tele HTTP/1.1
+GET /issuers/search?query=Big HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer <jwt>
 X-Share-Api-Key: <shareactor-api-key>
@@ -273,20 +273,20 @@ Content-type: application/json
 [  
    {  
       "verified":false,
-      "name":"Telenor Norge AS",
+      "name":"Big Company Inc",
       "account_number":"12345678903",
       "is_message_mandatory":false,
-      "address":{
-         "service":"google",
-         "street_name":"Fornebuveien 6",
-         "zip_code":"0556",
-         "alias":"",
-         "city":"Oslo",
-         "country":"NOR"
+      "logo_url":"<logo-url.png>",
+      "address": {
+          "street_name": "Money Lane 99",
+          "alias": "",
+          "service": "google",
+          "city": "Oslo",
+          "zip_code": "1234",
+          "country": "NOR"
       },
       "deleted":false,
       "blacklisted":false,
-      "logo_url":"http://logok.org/wp-content/uploads/2014/10/Telenor_logo-and-wordmark.png",
       "active":true,
       "created":{
          "$date":1491565328234
@@ -295,10 +295,10 @@ Content-type: application/json
          "$date":1491565328235
       },
       "_id":{
-         "$oid":"58e77b10b70e2a7650ea6521"
+         "$oid":"57ee9c72d76d431f85111433"
       },
       "company":{
-         "$oid":"58e77b10b70e2a7650ea651f"
+         "$oid":"57ee9c71d76d431f8511142f"
       }
    }
 ]
@@ -343,32 +343,32 @@ Content-Type: application/json
 {  
    "active":false,
    "company":{  
-      "$oid":"58e798d0b70e2a901ca32396"
+      "$oid":"57ee9c71d76d431f8511142f"
    },
-   "name":"Telenor Norge AS",
+   "name":"Big Company Inc",
    "account_number":"12345678903",
    "verified":false,
    "deleted":true,
    "_id":{  
-      "$oid":"58e798d0b70e2a901ca32398"
+      "$oid":"57ee9c72d76d431f85111433"
    },
    "blacklisted":false,
    "is_message_mandatory":false,
-   "address":{  
-      "service":"google",
-      "alias":"",
-      "zip_code":"0556",
-      "street_name":"Fornebuveien 6",
-      "country":"NOR",
-      "city":"Oslo"
+   "address": {
+       "street_name": "Money Lane 99",
+       "alias": "",
+       "service": "google",
+       "city": "Oslo",
+       "zip_code": "1234",
+       "country": "NOR"
    },
-   "created":{  
+   "created":{
       "$date":1491572944202
    },
    "modified":{  
       "$date":1491572947166
    },
-   "logo_url":"http://logok.org/wp-content/uploads/2014/10/Telenor_logo-and-wordmark.png"
+   "logo_url": "<logo-url.png>"
 }
 ```
 

--- a/source/includes/_payment_methods.md
+++ b/source/includes/_payment_methods.md
@@ -53,7 +53,7 @@ Content-Type: application/json
 
 {
   "company": {
-    "$oid": "<company-id>"
+    "$oid": "57ee9c71d76d431f8511142f"
   },
   "created": {
     "$date": 1476118043580
@@ -66,7 +66,7 @@ Content-Type: application/json
   },
   "deleted": false,
   "user": {
-    "$oid": "<user-id>"
+    "$oid": "57ee9c72d76d431f85111432"
   },
   "method": "dibs",
   "name": "DIBS",
@@ -130,7 +130,7 @@ Content-Type: application/json
 
 {
   "company": {
-    "$oid": "<company-id>"
+    "$oid": "57ee9c71d76d431f8511142f"
   },
   "created": {
     "$date": 1476118043580
@@ -143,7 +143,7 @@ Content-Type: application/json
   },
   "deleted": false,
   "user": {
-    "$oid": "<user-id>"
+    "$oid": "57ee9c72d76d431f85111432"
   },
   "method": "single_paypal",
   "name": "PayPal",
@@ -191,7 +191,7 @@ Content-Type: application/json
 
 {
   "company": {
-    "$oid": "<company-id>"
+    "$oid": "57ee9c71d76d431f8511142f"
   },
   "created": {
     "$date": 1476118043580
@@ -204,7 +204,7 @@ Content-Type: application/json
   },
   "deleted": false,
   "user": {
-    "$oid": "<user-id>"
+    "$oid": "57ee9c72d76d431f85111432"
   },
   "method": "future_paypal",
   "name": "PayPal",
@@ -249,12 +249,12 @@ Content-Type: application/json
   "masked_card_number":"XXXXXXXXXXXX1234",
   "merchant":"some_merchant_id",
   "user":{
-      "$oid":"57ee9705d76d431e56769b38"
+      "$oid":"57ee9c72d76d431f85111432"
   },
   "deleted":false,
   "method":"dibs",
   "company":{
-      "$oid":"57ee9705d76d431e56769b35"
+      "$oid":"57ee9c71d76d431f8511142f"
   },
   "created":{
       "$date":1475254021326
@@ -265,7 +265,7 @@ Content-Type: application/json
   },
   "active":true,
   "_id":{
-      "$oid":"57ee9705d76d431e56769b39"
+      "$oid":"<payment-method-id>"
   }
 }
 ```
@@ -304,12 +304,12 @@ Content-Type: application/json
     "masked_card_number":"XXXXXXXXXXXX1234",
     "merchant":"some_merchant_id",
     "user":{
-      "$oid":"57ee9705d76d431e56769b38"
+      "$oid":"57ee9c72d76d431f85111432"
     },
     "deleted":false,
     "method":"dibs",
     "company":{
-      "$oid":"57ee9705d76d431e56769b35"
+      "$oid":"57ee9c71d76d431f8511142f"
     },
     "created":{
       "$date":1475254021326
@@ -320,7 +320,7 @@ Content-Type: application/json
     },
     "active":true,
     "_id":{
-      "$oid":"57ee9705d76d431e56769b39"
+      "$oid":"<payment-method-id>"
     }
   }
 ]

--- a/source/includes/_payments.md
+++ b/source/includes/_payments.md
@@ -61,7 +61,7 @@ Content-Type: application/json
 
 {
   "company": {
-    "$oid": "<company-id>"
+    "$oid": "57ee9c71d76d431f8511142f"
   },
   "created": {
     "$date": 1476118043580
@@ -74,7 +74,7 @@ Content-Type: application/json
   },
   "deleted": false,
   "user": {
-    "$oid": "<user-id>"
+    "$oid": "57ee9c72d76d431f85111432"
   },
   "amount": 450.2,
   "metadata": {},
@@ -121,7 +121,7 @@ Content-Type: application/json
 
 {
   "company": {
-    "$oid": "<company-id>"
+    "$oid": "57ee9c71d76d431f8511142f"
   },
   "created": {
     "$date": 1476118043580
@@ -134,7 +134,7 @@ Content-Type: application/json
   },
   "deleted": false,
   "user": {
-    "$oid": "<user-id>"
+    "$oid": "57ee9c72d76d431f85111432"
   },
   "amount": 450.2,
   "metadata": {},
@@ -181,7 +181,7 @@ Content-Type: application/json
 [
   {
     "company": {
-      "$oid": "<company-id>"
+      "$oid": "57ee9c71d76d431f8511142f"
     },
     "created": {
       "$date": 1476118043580
@@ -194,7 +194,7 @@ Content-Type: application/json
     },
     "deleted": false,
     "user": {
-      "$oid": "<user-id>"
+      "$oid": "57ee9c72d76d431f85111432"
     },
     "amount": 450.2,
     "metadata": {},
@@ -202,7 +202,7 @@ Content-Type: application/json
     "active": true,
     "human_id": "51Q4LN",
     "currency": "NOK",
-    "subject": "<invoice-id>",
+    "subject": "57ee9c72d76d431f85111434",
     "payment_method": "<payment-method-id>",
     "payment_date": {
       "$date": 147998016470

--- a/source/includes/_products.md
+++ b/source/includes/_products.md
@@ -69,7 +69,7 @@ Content-Type: application/json
       -1
    ],
    "_cls":"Product",
-   "description":"zuuped prod",
+   "description":"",
    "modified":{  
       "$date":1492777046369
    },
@@ -81,7 +81,7 @@ Content-Type: application/json
    "tags":[],
    "vat":15.0,
    "company":{  
-      "$oid":"58f9f856b70e2a56c4a0db37"
+      "$oid":"57ee9c71d76d431f8511142f"
    },
    "deleted":false,
    "company_take":-1.0,
@@ -142,7 +142,9 @@ Content-Type: application/json
    "_cls":"Product",
    "parents":[],
    "tags":[  
-      "fuzz"
+      "fuzz",
+      "Foo",
+      "Bar"
    ],
    "price":3.14,
    "_sub_products":[],
@@ -161,13 +163,13 @@ Content-Type: application/json
       "$date":1492781492461
    },
    "company":{  
-      "$oid":"58fa09b4b70e2a4d743fdac2"
+      "$oid":"57ee9c71d76d431f8511142f"
    },
    "currency":"NOK",
    "path":"/",
    "main_product":true,
    "_id":{  
-      "$oid":"58fa09b4b70e2a4d743fdac4"
+      "$oid":"58f9f856b70e2a56c4a0db3d"
    },
    "business_rules":[],
    "default_position":[  
@@ -213,14 +215,14 @@ Content-Type: application/json
          "charge_id":"ch_1ADY0SEeeXxFpLJti58RcN7w"
       },
       "user":{  
-         "$oid":"59033056b70e2a1e086d5218"
+         "$oid":"57ee9c72d76d431f85111432"
       },
       "subject":{  
          "_cls":"Invoice",
-         "_ref":"59033056b70e2a1e086d521b"
+         "_ref":"57ee9c72d76d431f85111434"
       },
       "company":{  
-         "$oid":"5903304cb70e2a1e086d5213"
+         "$oid":"57ee9c71d76d431f8511142f"
       },
       "payment_date":{  
          "$date":1493381731652
@@ -230,14 +232,14 @@ Content-Type: application/json
          "$date":1493381732307
       },
       "_id":{  
-         "$oid":"59033265b70e2a1e086d521f"
+         "$oid":"58f9f856b70e2a56c4a0db3d"
       },
       "modified":{  
          "$date":1493381746495
       },
       "human_id":"VPXXN7",
       "payment_method":{  
-         "$oid":"59033058b70e2a1e086d521c"
+         "$oid":"<payment_method_id>"
       },
       "current_state":"succeeded",
       "deleted":false,

--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -152,7 +152,7 @@ Content-Type: application/json
    },
    "max_travel_time":1.0,
    "company":{
-      "$oid":"591ee147d57ba28fbe0a3883"
+      "$oid":"57ee9c71d76d431f8511142f"
    },
    "products":[
 
@@ -204,7 +204,7 @@ Content-Type: application/json
    "first_name":"John",
    "email":"john@email.com",
    "_id":{  
-      "$oid":"57f14227d76d43264a70c95d"
+      "$oid":"591ee147d57ba28fbe0a3892"
    },
    "auth0_id":"",
    "tags":[  
@@ -289,7 +289,7 @@ Content-Type: application/json
    },
    "max_travel_meters":10000.0,
    "country":"NOR",
-   "last_name":"Iversen",
+   "last_name":"Doe",
    "_cls":"User.Provider",
    "billing_address":{  
       "service":"google",
@@ -304,7 +304,7 @@ Content-Type: application/json
       "$date":1493962078526
    },
    "company":{  
-      "$oid":"590c0d5eb70e2a13944ad508"
+      "$oid":"57ee9c71d76d431f8511142f"
    },
    "deleted":false,
    "roles":[  
@@ -347,7 +347,7 @@ Content-Type: application/json
        "first_name":"John",
        "email":"john@email.com",
        "_id":{  
-          "$oid":"57f14227d76d43264a70c95d"
+          "$oid":"591ee147d57ba28fbe0a3892"
        },
        "auth0_id":"",
        "tags":[  
@@ -432,7 +432,7 @@ Content-Type: application/json
        },
        "max_travel_meters":10000.0,
        "country":"NOR",
-       "last_name":"Iversen",
+       "last_name":"Doe",
        "_cls":"User.Provider",
        "billing_address":{  
           "service":"google",
@@ -447,7 +447,7 @@ Content-Type: application/json
           "$date":1493962078526
        },
        "company":{  
-          "$oid":"590c0d5eb70e2a13944ad508"
+          "$oid":"57ee9c71d76d431f8511142f"
        },
        "deleted":false,
        "roles":[  

--- a/source/includes/_tags.md
+++ b/source/includes/_tags.md
@@ -1,1 +1,3 @@
 # Tags
+
+Documentation not ready.

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -101,7 +101,7 @@ Content-Type: application/json
 
 {
   "_id":{
-    "$oid":"57f14227d76d43264a70c95d"
+    "$oid":"57ee9c72d76d431f85111432"
   },
   "_cls":"User",
   "created":{
@@ -120,7 +120,7 @@ Content-Type: application/json
   "note":"",
   "avatar":"",
   "company":{
-    "$oid":"57f14227d76d43264a70c93c"
+    "$oid":"57ee9c71d76d431f8511142f"
   },
   "tags":[],
   "stripe_customer_id":"",
@@ -158,7 +158,7 @@ Content-Type: application/json
 
 {
   "_id":{
-    "$oid":"57f14227d76d43264a70c95d"
+    "$oid":"57ee9c72d76d431f85111432"
   },
   "_cls":"User",
   "created":{
@@ -177,7 +177,7 @@ Content-Type: application/json
   "note":"",
   "avatar":"",
   "company":{
-    "$oid":"57f14227d76d43264a70c93c"
+    "$oid":"57ee9c71d76d431f8511142f"
   },
   "tags":[],
   "stripe_customer_id":"",
@@ -218,7 +218,7 @@ Content-Type: application/json
 
 {
   "_id":{
-    "$oid":"57f14227d76d43264a70c95d"
+    "$oid":"57ee9c72d76d431f85111432"
   },
   "_cls":"User",
   "created":{
@@ -237,7 +237,7 @@ Content-Type: application/json
   "note":"",
   "avatar":"",
   "company":{
-    "$oid":"57f14227d76d43264a70c93c"
+    "$oid":"57ee9c71d76d431f8511142f"
   },
   "tags":[],
   "stripe_customer_id":"",
@@ -273,7 +273,7 @@ Content-Type: application/json
 [
   {
   "_id":{
-    "$oid":"57f14227d76d43264a70c95d"
+    "$oid":"57ee9c72d76d431f85111432"
   },
   "_cls":"User",
   "created":{
@@ -292,7 +292,7 @@ Content-Type: application/json
   "note":"",
   "avatar":"",
   "company":{
-    "$oid":"57f14227d76d43264a70c93c"
+    "$oid":"57ee9c71d76d431f8511142f"
   },
   "tags":[],
   "stripe_customer_id":"",
@@ -329,7 +329,7 @@ Content-Type: application/json
 [
   {
   "_id":{
-    "$oid":"57f14227d76d43264a70c95d"
+    "$oid":"57ee9c72d76d431f85111432"
   },
   "_cls":"User",
   "created":{
@@ -348,7 +348,7 @@ Content-Type: application/json
   "note":"",
   "avatar":"",
   "company":{
-    "$oid":"57f14227d76d43264a70c93c"
+    "$oid":"57ee9c71d76d431f8511142f"
   },
   "tags":[],
   "stripe_customer_id":"",

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -14,16 +14,18 @@ includes:
   - users
   - providers
   - products
-  - bulks
   - orders
-  - tags
-  - campaigns
   - invoices
   - issuers
   - payment_methods
   - payments
   - address
   - phone_nr_verification
+  - bulks
+  - tags
+  - campaigns
+
+
 
 
 search: true


### PR DESCRIPTION
Some cleaning of id's in the documentation.

The same user id for all users, same company id, same products id, same issuer id.

The payment and payent_method ids i put as it where, as <payment_id> and <payment_method_id> because it did not have any examples to gather ids from.

Did also some cleaning regarding username and issuer name